### PR TITLE
UWS test updates

### DIFF
--- a/UWSLib/test/uws/config/TestUWSConfiguration.java
+++ b/UWSLib/test/uws/config/TestUWSConfiguration.java
@@ -282,7 +282,7 @@ public class TestUWSConfiguration {
 			assertNotNull(aClass);
 			assertEquals(ClassWithAPrimitiveConstructor.class, aClass.getClass());
 			assertEquals(123, aClass.myParam);
-			aClass = newInstance("{uws.config.TestUWSConfiguration$ClassWithAPrimitiveConstructor}", "aClass", ClassWithAPrimitiveConstructor.class, new Class<?>[]{int.class}, new Object[]{new Integer(123)});
+			aClass = newInstance("{uws.config.TestUWSConfiguration$ClassWithAPrimitiveConstructor}", "aClass", ClassWithAPrimitiveConstructor.class, new Class<?>[]{int.class}, new Object[]{123});
 			assertNotNull(aClass);
 			assertEquals(ClassWithAPrimitiveConstructor.class, aClass.getClass());
 			assertEquals(123, aClass.myParam);
@@ -293,7 +293,7 @@ public class TestUWSConfiguration {
 
 		// WRONG CONSTRUCTOR with primitive type:
 		try{
-			newInstance("{uws.config.TestUWSConfiguration$ClassWithAPrimitiveConstructor}", "aClass", ClassWithAPrimitiveConstructor.class, new Class<?>[]{Integer.class}, new Object[]{new Integer(123)});
+			newInstance("{uws.config.TestUWSConfiguration$ClassWithAPrimitiveConstructor}", "aClass", ClassWithAPrimitiveConstructor.class, new Class<?>[]{Integer.class}, new Object[]{123});
 			fail("This MUST have failed because the constructor of the specified class expects an int, not an java.lang.Integer!");
 		}catch(Exception ex){
 			assertEquals(UWSException.class, ex.getClass());

--- a/UWSLib/test/uws/job/serializer/filter/TestJobListRefiner.java
+++ b/UWSLib/test/uws/job/serializer/filter/TestJobListRefiner.java
@@ -24,19 +24,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import jakarta.servlet.AsyncContext;
-import jakarta.servlet.DispatcherType;
-import jakarta.servlet.RequestDispatcher;
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletInputStream;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
-import jakarta.servlet.http.Part;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
 
 import org.junit.Test;
 
@@ -715,7 +704,7 @@ public class TestJobListRefiner {
 
 	protected final static class TestHttpServletRequest implements HttpServletRequest {
 
-		private HashMap<String,String[]> parameters = new HashMap<String,String[]>();
+		private final HashMap<String,String[]> parameters = new HashMap<String,String[]>();
 
 		private static class NamesEnumeration implements Enumeration<String> {
 
@@ -856,11 +845,6 @@ public class TestJobListRefiner {
 		}
 
 		@Override
-		public String getRealPath(String arg0){
-			return null;
-		}
-
-		@Override
 		public BufferedReader getReader() throws IOException{
 			return null;
 		}
@@ -906,12 +890,32 @@ public class TestJobListRefiner {
 		}
 
 		@Override
+		public String getRequestId() {
+			return "";
+		}
+
+		@Override
+		public String getProtocolRequestId() {
+			return "";
+		}
+
+		@Override
+		public ServletConnection getServletConnection() {
+			return null;
+		}
+
+		@Override
 		public String getContentType(){
 			return null;
 		}
 
 		@Override
 		public int getContentLength(){
+			return 0;
+		}
+
+		@Override
+		public long getContentLengthLong() {
 			return 0;
 		}
 
@@ -952,11 +956,6 @@ public class TestJobListRefiner {
 		}
 
 		@Override
-		public boolean isRequestedSessionIdFromUrl(){
-			return false;
-		}
-
-		@Override
 		public boolean isRequestedSessionIdFromURL(){
 			return false;
 		}
@@ -979,6 +978,11 @@ public class TestJobListRefiner {
 		@Override
 		public HttpSession getSession(){
 			return null;
+		}
+
+		@Override
+		public String changeSessionId() {
+			return "";
 		}
 
 		@Override
@@ -1028,6 +1032,11 @@ public class TestJobListRefiner {
 
 		@Override
 		public Part getPart(String arg0) throws IOException, IllegalStateException, ServletException{
+			return null;
+		}
+
+		@Override
+		public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) throws IOException, ServletException {
 			return null;
 		}
 

--- a/UWSLib/test/uws/service/TestUWSUrl.java
+++ b/UWSLib/test/uws/service/TestUWSUrl.java
@@ -14,19 +14,8 @@ import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Map;
 
-import jakarta.servlet.AsyncContext;
-import jakarta.servlet.DispatcherType;
-import jakarta.servlet.RequestDispatcher;
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletInputStream;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
-import jakarta.servlet.http.Part;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -121,12 +110,32 @@ public class TestUWSUrl {
 		}
 
 		@Override
+		public long getContentLengthLong() {
+			return 0;
+		}
+
+		@Override
 		public String getContentType(){
 			return null;
 		}
 
 		@Override
 		public DispatcherType getDispatcherType(){
+			return null;
+		}
+
+		@Override
+		public String getRequestId() {
+			return "";
+		}
+
+		@Override
+		public String getProtocolRequestId() {
+			return "";
+		}
+
+		@Override
+		public ServletConnection getServletConnection() {
 			return null;
 		}
 
@@ -187,11 +196,6 @@ public class TestUWSUrl {
 
 		@Override
 		public BufferedReader getReader() throws IOException{
-			return null;
-		}
-
-		@Override
-		public String getRealPath(String arg0){
 			return null;
 		}
 
@@ -311,6 +315,11 @@ public class TestUWSUrl {
 		}
 
 		@Override
+		public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) throws IOException, ServletException {
+			return null;
+		}
+
+		@Override
 		public Collection<Part> getParts() throws IOException, IllegalStateException, ServletException{
 			return null;
 		}
@@ -341,6 +350,11 @@ public class TestUWSUrl {
 		}
 
 		@Override
+		public String changeSessionId() {
+			return "";
+		}
+
+		@Override
 		public HttpSession getSession(boolean arg0){
 			return null;
 		}
@@ -357,11 +371,6 @@ public class TestUWSUrl {
 
 		@Override
 		public boolean isRequestedSessionIdFromURL(){
-			return false;
-		}
-
-		@Override
-		public boolean isRequestedSessionIdFromUrl(){
 			return false;
 		}
 

--- a/UWSLib/test/uws/service/actions/TestJobSummary.java
+++ b/UWSLib/test/uws/service/actions/TestJobSummary.java
@@ -18,19 +18,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import jakarta.servlet.AsyncContext;
-import jakarta.servlet.DispatcherType;
-import jakarta.servlet.RequestDispatcher;
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletInputStream;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
-import jakarta.servlet.http.Part;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -415,11 +404,6 @@ public class TestJobSummary {
 		}
 
 		@Override
-		public String getRealPath(String arg0){
-			return null;
-		}
-
-		@Override
 		public BufferedReader getReader() throws IOException{
 			return null;
 		}
@@ -465,12 +449,32 @@ public class TestJobSummary {
 		}
 
 		@Override
+		public String getRequestId() {
+			return "";
+		}
+
+		@Override
+		public String getProtocolRequestId() {
+			return "";
+		}
+
+		@Override
+		public ServletConnection getServletConnection() {
+			return null;
+		}
+
+		@Override
 		public String getContentType(){
 			return null;
 		}
 
 		@Override
 		public int getContentLength(){
+			return 0;
+		}
+
+		@Override
+		public long getContentLengthLong() {
 			return 0;
 		}
 
@@ -511,11 +515,6 @@ public class TestJobSummary {
 		}
 
 		@Override
-		public boolean isRequestedSessionIdFromUrl(){
-			return false;
-		}
-
-		@Override
 		public boolean isRequestedSessionIdFromURL(){
 			return false;
 		}
@@ -538,6 +537,11 @@ public class TestJobSummary {
 		@Override
 		public HttpSession getSession(){
 			return null;
+		}
+
+		@Override
+		public String changeSessionId() {
+			return "";
 		}
 
 		@Override
@@ -587,6 +591,11 @@ public class TestJobSummary {
 
 		@Override
 		public Part getPart(String arg0) throws IOException, IllegalStateException, ServletException{
+			return null;
+		}
+
+		@Override
+		public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) throws IOException, ServletException {
 			return null;
 		}
 

--- a/UWSLib/test/uws/service/wait/TestUserLimitedBlockingPolicy.java
+++ b/UWSLib/test/uws/service/wait/TestUserLimitedBlockingPolicy.java
@@ -19,19 +19,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import jakarta.servlet.AsyncContext;
-import jakarta.servlet.DispatcherType;
-import jakarta.servlet.RequestDispatcher;
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletInputStream;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
-import jakarta.servlet.http.Part;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -476,11 +465,6 @@ public class TestUserLimitedBlockingPolicy {
 		}
 
 		@Override
-		public String getRealPath(String arg0){
-			return null;
-		}
-
-		@Override
 		public BufferedReader getReader() throws IOException{
 			return null;
 		}
@@ -526,12 +510,32 @@ public class TestUserLimitedBlockingPolicy {
 		}
 
 		@Override
+		public String getRequestId() {
+			return "";
+		}
+
+		@Override
+		public String getProtocolRequestId() {
+			return "";
+		}
+
+		@Override
+		public ServletConnection getServletConnection() {
+			return null;
+		}
+
+		@Override
 		public String getContentType(){
 			return null;
 		}
 
 		@Override
 		public int getContentLength(){
+			return 0;
+		}
+
+		@Override
+		public long getContentLengthLong() {
 			return 0;
 		}
 
@@ -572,11 +576,6 @@ public class TestUserLimitedBlockingPolicy {
 		}
 
 		@Override
-		public boolean isRequestedSessionIdFromUrl(){
-			return false;
-		}
-
-		@Override
 		public boolean isRequestedSessionIdFromURL(){
 			return false;
 		}
@@ -599,6 +598,11 @@ public class TestUserLimitedBlockingPolicy {
 		@Override
 		public HttpSession getSession(){
 			return null;
+		}
+
+		@Override
+		public String changeSessionId() {
+			return "";
 		}
 
 		@Override
@@ -648,6 +652,11 @@ public class TestUserLimitedBlockingPolicy {
 
 		@Override
 		public Part getPart(String arg0) throws IOException, IllegalStateException, ServletException{
+			return null;
+		}
+
+		@Override
+		public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) throws IOException, ServletException {
 			return null;
 		}
 


### PR DESCRIPTION
Updated instantiation of Integer in test classes
Added missing placeholders for the derived HttpServletRequest classes (in test only)

Three unit tests still failing:
1. TestISO8601Format.java
Seems to work fine if I set the timezone on my computer to France but fails in other timezones

assertEquals(ISO8601Format.format(date, TimeZone.getDefault().getID(), true, false), ISO8601Format.format(date, null, true, false));


2. UWSUrl.java

/* ******************** */
	/* URL BUILDING METHODS */
	/* ******************** */
	/** Gets the base UWS URI = UWS home page. */
	public final UWSUrl homePage(){
		UWSUrl url = new UWSUrl(this);
		**url.setUwsURI(null);				//Results in //localhost:8080/tapTest/path being removed,** which makes the test fail
		return url;
	}


TestUWSUrl.java
	assertEquals("http://localhost:8080/tapTest/path/async/123456A", uu.jobSummary("async", "123456A").toString());
ends up comparing "_http:////localhost:8080/tapTest/path/async/job number_" with "_http:async/job number_"


3. testExtractBaseURI method seems to fail for the same reason, the host has been nullified immediately in uu.getUwsURI() calls